### PR TITLE
feat: Allow Overriding of default mixins

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export const mixins = <T extends IStitchesMixins = {}>(
 ) => () => (
   key: keyof T | TDefaultStitchesMixin | (keyof T | TDefaultStitchesMixin)[]
 ) => {
-  const mixins = { ...customMixins, ...defaultMixins };
+  const mixins = { ...defaultMixins, ...customMixins };
 
   return Array.isArray(key)
     ? key.reduce((acc, cv) => ({ ...acc, ...mixins[cv] }), {})


### PR DESCRIPTION
Really love the project but I would like to override the `box` mixin with some of my homegrown properties on my projects, This would allow for that behavior!

it also means you can provide more default mixins and let people override them if they want to use their own, no name collision!

Your project, your call on if you want to merge it up!